### PR TITLE
Refactor of class accessing to allow usage of `self`; minor string formatting bugfix

### DIFF
--- a/MISOReports/MISOReports.py
+++ b/MISOReports/MISOReports.py
@@ -15,8 +15,8 @@ class URLBuilder(ABC):
         file_extension: str,
     ) -> str:
         pass
-    
-    
+
+
 class MISORTWDDataBrokerURLBuilder(URLBuilder):
     def __init__(
         self,
@@ -26,7 +26,7 @@ class MISORTWDDataBrokerURLBuilder(URLBuilder):
         self.target = target
         self.supported_extensions = supported_extensions
 
-        self._format_url = f"https://api.misoenergy.org/MISORTWDDataBroker/DataBrokerServices.asmx?messageType={target}&returnType={URLBuilder.extension_placeholder}"
+        self._format_url = f"https://api.misoenergy.org/MISORTWDDataBroker/DataBrokerServices.asmx?messageType={target}&returnType={self.extension_placeholder}"
 
     def build_url(
         self,
@@ -34,8 +34,8 @@ class MISORTWDDataBrokerURLBuilder(URLBuilder):
     ) -> str:
         if file_extension not in self.supported_extensions:
             raise ValueError(f"Unsupported file extension: {file_extension}")
-        
-        res = self._format_url.replace(URLBuilder.extension_placeholder, file_extension)
+
+        res = self._format_url.replace(self.extension_placeholder, file_extension)
         return res
 
 
@@ -48,7 +48,7 @@ class MISORTWDBIReporterURLBuilder(URLBuilder):
         self.target = target
         self.supported_extensions = supported_extensions
 
-        self._format_url = f"https://api.misoenergy.org/MISORTWDBIReporter/Reporter.asmx?messageType={target}&returnType={URLBuilder.extension_placeholder}"
+        self._format_url = f"https://api.misoenergy.org/MISORTWDBIReporter/Reporter.asmx?messageType={target}&returnType={self.extension_placeholder}"
 
     def build_url(
         self,
@@ -56,10 +56,10 @@ class MISORTWDBIReporterURLBuilder(URLBuilder):
     ) -> str:
         if file_extension not in self.supported_extensions:
             raise ValueError(f"Unsupported file extension: {file_extension}")
-        
-        res = self._format_url.replace(URLBuilder.extension_placeholder, file_extension)
+
+        res = self._format_url.replace(self.extension_placeholder, file_extension)
         return res
-    
+
 
 class MISOMarketReportsURLBuilder(URLBuilder):
     def __init__(
@@ -80,47 +80,52 @@ class MISOMarketReportsURLBuilder(URLBuilder):
     ) -> str:
         if file_extension not in self.supported_extensions:
             raise ValueError(f"Unsupported file extension: {file_extension}")
-        
+
         res = self.url_generator(ddatetime, self.target)
-        res = res.replace(URLBuilder.extension_placeholder, file_extension)
+        res = res.replace(self.extension_placeholder, file_extension)
         return res
-    
+
     def url_generator_datetime_first(
+        self,
         ddatetime: datetime.datetime,
         target: str,
         datetime_format: str,
     ) -> str:
-        format_string = f"https://docs.misoenergy.org/marketreports/{datetime_format}_{target}.{URLBuilder.extension_placeholder}"
+        format_string = f"https://docs.misoenergy.org/marketreports/{datetime_format}_{target}.{self.extension_placeholder}"
         res = ddatetime.strftime(format_string)
         return res
-    
+
     def url_generator_YYYYmmdd_first(
+        self,
         ddatetime: datetime.datetime,
         target: str,
     ) -> str:
-        return MISOMarketReportsURLBuilder.url_generator_datetime_first(ddatetime, target, "%Y%m%d")
-    
+        return self.url_generator_datetime_first(ddatetime, target, "%Y%m%d")
+
     def url_generator_YYYYmm_first(
+        self,
         ddatetime: datetime.datetime,
         target: str,
     ) -> str:
-        return MISOMarketReportsURLBuilder.url_generator_datetime_first(ddatetime, target, "%Y%m")
-    
+        return self.url_generator_datetime_first(ddatetime, target, "%Y%m")
+
     def url_generator_YYYY_current_month_name_to_two_months_later_name_first(
+        self,
         ddatetime: datetime.datetime,
         target: str,
     ) -> str:
-        new_month = (ddatetime.month + 2) % 12 
+        new_month = (ddatetime.month + 2) % 12
         two_months_later_datetime = ddatetime.replace(month=new_month)
-        datetime_part = f"{ddatetime.strftime('%Y')}-{ddatetime.strftime('%b')}-{two_months_later_datetime.strftime('%b')}" 
-        res = f"https://docs.misoenergy.org/marketreports/{datetime_part}_{target}.{URLBuilder.extension_placeholder}"
+        datetime_part = f"{ddatetime.strftime('%Y')}-{ddatetime.strftime('%b')}-{two_months_later_datetime.strftime('%b')}"
+        res = f"https://docs.misoenergy.org/marketreports/{datetime_part}_{target}.{self.extension_placeholder}"
         return res
-    
+
     def url_generator_YYYYmmdd_last(
+        self,
         ddatetime: datetime.datetime,
         target: str,
     ) -> str:
-        res = f"https://docs.misoenergy.org/marketreports/{target}_{ddatetime.strftime('%Y%m%d')}.{URLBuilder.extension_placeholder}"
+        res = f"https://docs.misoenergy.org/marketreports/{target}_{ddatetime.strftime('%Y%m%d')}.{self.extension_placeholder}"
         return res
 
 

--- a/MISOReports/test_MISOReports.py
+++ b/MISOReports/test_MISOReports.py
@@ -17,13 +17,13 @@ from MISOReports.MISOReports import (
     ]
 )
 def test_MISORTWDDataBrokerURLBuilder_build_url_extension_supported(
-    target, 
-    supported_extensions, 
-    file_extension, 
+    target,
+    supported_extensions,
+    file_extension,
     expected,
 ):
     url_builder = MISORTWDDataBrokerURLBuilder(
-        target=target, 
+        target=target,
         supported_extensions=supported_extensions,
     )
 
@@ -39,12 +39,12 @@ def test_MISORTWDDataBrokerURLBuilder_build_url_extension_supported(
     ]
 )
 def test_MISORTWDDataBrokerURLBuilder_build_url_extension_not_supported(
-    target, 
-    supported_extensions, 
-    file_extension, 
+    target,
+    supported_extensions,
+    file_extension,
 ):
     url_builder = MISORTWDDataBrokerURLBuilder(
-        target=target, 
+        target=target,
         supported_extensions=supported_extensions,
     )
 
@@ -58,13 +58,13 @@ def test_MISORTWDDataBrokerURLBuilder_build_url_extension_not_supported(
     ]
 )
 def test_MISORTWDBIReporterURLBuilder_build_url_extension_supported(
-    target, 
-    supported_extensions, 
-    file_extension, 
+    target,
+    supported_extensions,
+    file_extension,
     expected,
 ):
     url_builder = MISORTWDBIReporterURLBuilder(
-        target=target, 
+        target=target,
         supported_extensions=supported_extensions,
     )
 
@@ -73,26 +73,25 @@ def test_MISORTWDBIReporterURLBuilder_build_url_extension_supported(
 
 @pytest.mark.parametrize(
     "target, supported_extensions, url_generator, ddatetime, file_extension, expected", [
-        ("DA_Load_EPNodes", ["zip"], MISOMarketReportsURLBuilder.url_generator_YYYYmmdd_last, datetime.datetime(year=2024, month=10, day=21), "zip", "https://docs.misoenergy.org/marketreports/DA_Load_EPNodes_20241021.zip"),
-        ("da_exante_lmp", ["csv"], MISOMarketReportsURLBuilder.url_generator_YYYYmmdd_first, datetime.datetime(year=2024, month=10, day=26), "csv", "https://docs.misoenergy.org/marketreports/20241026_da_exante_lmp.csv"),
-        ("da_expost_lmp", ["csv"], MISOMarketReportsURLBuilder.url_generator_YYYYmmdd_first, datetime.datetime(year=2024, month=10, day=26), "csv", "https://docs.misoenergy.org/marketreports/20241026_da_expost_lmp.csv"),
-        ("DA_LMPs", ["zip"], MISOMarketReportsURLBuilder.url_generator_YYYY_current_month_name_to_two_months_later_name_first, datetime.datetime(year=2024, month=7, day=1), "zip", "https://docs.misoenergy.org/marketreports/2024-Jul-Sep_DA_LMPs.zip"),
-        ("rt_expost_str_5min_mcp", ["xlsx"], MISOMarketReportsURLBuilder.url_generator_YYYYmm_first, datetime.datetime(year=2024, month=10, day=1), "xlsx", "https://docs.misoenergy.org/marketreports/202410_rt_expost_str_5min_mcp.xlsx"),
+        ("DA_Load_EPNodes", ["zip"], "url_generator_YYYYmmdd_last", datetime.datetime(year=2024, month=10, day=21), "zip", "https://docs.misoenergy.org/marketreports/DA_Load_EPNodes_20241021.zip"),
+        ("da_exante_lmp", ["csv"], "url_generator_YYYYmmdd_first", datetime.datetime(year=2024, month=10, day=26), "csv", "https://docs.misoenergy.org/marketreports/20241026_da_exante_lmp.csv"),
+        ("da_expost_lmp", ["csv"], "url_generator_YYYYmmdd_first", datetime.datetime(year=2024, month=10, day=26), "csv", "https://docs.misoenergy.org/marketreports/20241026_da_expost_lmp.csv"),
+        ("DA_LMPs", ["zip"], "url_generator_YYYY_current_month_name_to_two_months_later_name_first", datetime.datetime(year=2024, month=7, day=1), "zip", "https://docs.misoenergy.org/marketreports/2024-Jul-Sep_DA_LMPs.zip"),
+        ("rt_expost_str_5min_mcp", ["xlsx"], "url_generator_YYYYmm_first", datetime.datetime(year=2024, month=10, day=1), "xlsx", "https://docs.misoenergy.org/marketreports/202410_rt_expost_str_5min_mcp.xlsx"),
     ]
 )
-def test_MISOMarketReportsURLBuilder_build_url(   
-    target, 
-    supported_extensions, 
+def test_MISOMarketReportsURLBuilder_build_url(
+    target,
+    supported_extensions,
     url_generator,
     ddatetime,
     file_extension,
-    expected, 
+    expected,
 ):
     url_builder = MISOMarketReportsURLBuilder(
-        target=target, 
+        target=target,
         supported_extensions=supported_extensions,
-        url_generator=url_generator
+        url_generator=lambda dt, tgt: getattr(url_builder, url_generator)(dt, tgt),
     )
 
     assert url_builder.build_url(ddatetime=ddatetime, file_extension=file_extension) == expected
-


### PR DESCRIPTION
- Reworked the `URLBuilder` classes to allow usage of `self` in methods, making future development easier
    -  Adjusted PyTests accordingly - they now use `getattr` to retrieve the specified method from the `URLBuilder` instance
- Fixed minor string formatting issue with quote matching in  `MISOMarketReportsURLBuilder.url_generator_YYYYmmdd_last`