### PR TITLE
Adjusted lmpconsolidatedtable parser to handle time 24:00

### DIFF
--- a/MISOReports/parsers.py
+++ b/MISOReports/parsers.py
@@ -1599,6 +1599,9 @@ def parse_lmpconsolidatedtable(
                 hour = f"{int(time.split()[1])}:00"
             else:
                 hour = time
+            
+            if hour == "24:00":
+                hour = "00:00"
 
             metadata_names.append(name)
             metadata_times.append(hour)


### PR DESCRIPTION
Fix for a bug that affected this real-time report when parsed near midnight (24:00).